### PR TITLE
Fix else transformation to use all old variables

### DIFF
--- a/program/transformer/if_transformer.py
+++ b/program/transformer/if_transformer.py
@@ -57,7 +57,7 @@ class IfTransformer(TreeTransformer):
                             assign.variable
                         ]
             extra_condition = current_condition.copy().simplify()
-            extra_condition.subs(current_rename_subs)
+            extra_condition.subs(rename_subs)
 
             # Add the branch conditions to the assignments
             for assign in branch:

--- a/program/transformer/if_transformer.py
+++ b/program/transformer/if_transformer.py
@@ -41,21 +41,14 @@ class IfTransformer(TreeTransformer):
                 else And(not_previous, conditions[i])
             )
 
-            # Remember variables which appear in a condition and are assigned within the branch
-            current_rename_subs = {}
+            # Remember variables which appear in a condition and are assigned
+            # within the branch or any previous one
             for assign in branch:
                 if assign.variable in condition_symbols:
-                    if assign.variable in rename_subs:
-                        current_rename_subs[assign.variable] = rename_subs[
-                            assign.variable
-                        ]
-                    else:
-                        current_rename_subs[assign.variable] = get_unique_var(
+                    if assign.variable not in rename_subs:
+                        rename_subs[assign.variable] = get_unique_var(
                             name="old"
                         )
-                        rename_subs[assign.variable] = current_rename_subs[
-                            assign.variable
-                        ]
             extra_condition = current_condition.copy().simplify()
             extra_condition.subs(rename_subs)
 

--- a/program/transformer/if_transformer.py
+++ b/program/transformer/if_transformer.py
@@ -46,9 +46,7 @@ class IfTransformer(TreeTransformer):
             for assign in branch:
                 if assign.variable in condition_symbols:
                     if assign.variable not in rename_subs:
-                        rename_subs[assign.variable] = get_unique_var(
-                            name="old"
-                        )
+                        rename_subs[assign.variable] = get_unique_var(name="old")
             extra_condition = current_condition.copy().simplify()
             extra_condition.subs(rename_subs)
 

--- a/tests/benchmarks/else_transformation.prob
+++ b/tests/benchmarks/else_transformation.prob
@@ -1,0 +1,12 @@
+x = 0
+c = 1
+while c == 1:
+    if c == 1:
+        x = x + 1
+        c = Bernoulli(1/2)
+    else:
+        x = x + 1
+    end
+end
+
+#test: raw; x; 0; 2 - 2/2**n


### PR DESCRIPTION
Consider the following program:
```
x = 0
c = 1
while c == 1:
    if c == 1:
        x = x + 1
        c = Bernoulli(1/2)
    else:
        x = x + 1
    end
end
```

The else branch should be dead code. However, its inclusion causes the analysis to change from `E(x) = 0; 2 - 2/2**n` to the incorrect result  `E(x) = 0; 3 - 3/2**n`. This happens because the else transformation does not replace `c` with the variable storing its old value in the transformed else condition `!(c == 1)`.

This PR makes the appropriate fix and adds the above example as a regression test.