### PR TITLE
Add Dockerfile as alternative to local python/pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:latest
+WORKDIR /polar
+COPY . .
+RUN pip install -r requirements.txt
+ENTRYPOINT ["python", "polar.py"]

--- a/README.md
+++ b/README.md
@@ -121,6 +121,22 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+Alternatively, build Polar as a Docker container using the provided `Dockerfile`.
+
+1. Clone the repository:
+   ```bash
+   git clone git@github.com:probing-lab/polar.git
+   cd polar
+   ```
+2. Build the Docker container.
+   ```bash
+   docker build . -t polar
+   ```
+3. Execute the container.
+   ```bash
+   docker run --rm -v "$(pwd):$(pwd)" polar documentation/loops/loop.prob --goals "E(x)"
+   ```
+
 ## Supported Loops
 
 The problems Polar can solve are uncomputable for arbitrary probabilistic loops. This means that an algorithm and a


### PR DESCRIPTION
Python's virtual environments can be inconvenient in some setups. This offers an alternative following the standard Docker pattern for command-line tools.